### PR TITLE
cli: command for managing indexing queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ services:
   - rabbitmq
 
 env:
-  - REQUIREMENTS=lowest BROKER_URL=memory://
-  - REQUIREMENTS=release BROKER_URL=memory://
-  - REQUIREMENTS=devel BROKER_URL=memory://
   - REQUIREMENTS=lowest BROKER_URL=redis://localhost:6379/0
   - REQUIREMENTS=lowest BROKER_URL=amqp://localhost:5672//
   - REQUIREMENTS=release BROKER_URL=redis://localhost:6379/0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def test_run(script_info):
     assert 'Starting 2 tasks' in res.output
 
 
-def test_reindex(app, script_info, queue):
+def test_reindex(app, script_info):
     """Test reindex."""
     # load records
     with app.test_request_context():
@@ -59,6 +59,11 @@ def test_reindex(app, script_info, queue):
         data = {'title': 'Test0'}
         record = Record.create(data, id_=rec_uuid)
         db.session.commit()
+
+        # Initialize queue
+        res = runner.invoke(cli.queue, ['init', 'purge'],
+                            obj=script_info)
+        assert 0 == res.exit_code
 
         res = runner.invoke(cli.reindex, ['--yes-i-know'], obj=script_info)
         assert 0 == res.exit_code
@@ -71,3 +76,8 @@ def test_reindex(app, script_info, queue):
         res = current_search_client.get(index=index, doc_type=doc_type,
                                         id=rec_uuid)
         assert res['found']
+
+        # Destroy queue
+        res = runner.invoke(cli.queue, ['delete'],
+                            obj=script_info)
+        assert 0 == res.exit_code


### PR DESCRIPTION
* Adds new command group `queue` with chainable commands `init`,
  `purge`, and `delete` for managing indexing queue.  (closes #11)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>