### PR TITLE
config: INDEXER_BULK_REQUEST_TIMEOUT addition

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,14 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
+
+_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '{0}:{1}'.format(get_source_line(node)))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/invenio_indexer/api.py
+++ b/invenio_indexer/api.py
@@ -190,10 +190,13 @@ class RecordIndexer(object):
                 routing_key=self.mq_routing_key,
             )
 
+            req_timeout = current_app.config['INDEXER_BULK_REQUEST_TIMEOUT']
+
             count = bulk(
                 self.client,
                 self._actionsiter(consumer.iterqueue()),
                 stats_only=True,
+                request_timeout=req_timeout
             )
 
             consumer.close()

--- a/invenio_indexer/api.py
+++ b/invenio_indexer/api.py
@@ -196,7 +196,7 @@ class RecordIndexer(object):
                 self.client,
                 self._actionsiter(consumer.iterqueue()),
                 stats_only=True,
-                request_timeout=req_timeout
+                request_timeout=req_timeout,
             )
 
             consumer.close()

--- a/invenio_indexer/config.py
+++ b/invenio_indexer/config.py
@@ -46,3 +46,6 @@ INDEXER_MQ_ROUTING_KEY = 'indexer'
 
 INDEXER_REPLACE_REFS = True
 """Whether to replace JSONRefs prior to indexing record."""
+
+INDEXER_BULK_REQUEST_TIMEOUT = 10
+"""Request timeout to use in Bulk indexing."""

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.3',
+        'Sphinx>=1.4',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
* Allows configuring the timeout used when sending bulk requests. Increasing
  this value is useful when the records to index are big, which can cause
  an indexing timeout.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>