### PR TITLE
config: addition of INDEXER_BEFORE_INDEX_HOOKS

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,8 +27,12 @@ Authors
 
 Indexer for Invenio.
 
-- Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
-- Jiri Kuncar <jiri.kuncar@cern.ch>
-- Leonardo Rossi <leonardo.r@cern.ch>
-- Javier Martin Montull <javier.martin.montull@cern.ch>
 - Alizee Pace <alizee.pace@gmail.com>
+- Javier Martin Montull <javier.martin.montull@cern.ch>
+- Jiri Kuncar <jiri.kuncar@cern.ch>
+- Krzysztof Nowak <k.nowak@cern.ch>
+- Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+- Leonardo Rossi <leonardo.r@cern.ch>
+- Nicolas Harraudeau <nicolas.harraudeau@cern.ch>
+- Salvatore Zaza <salvatore.zaza@gmail.com>
+- Tibor Simko <tibor.simko@cern.ch>

--- a/invenio_indexer/config.py
+++ b/invenio_indexer/config.py
@@ -52,3 +52,6 @@ INDEXER_BULK_REQUEST_TIMEOUT = 10
 
 INDEXER_RECORD_TO_INDEX = 'invenio_indexer.utils.default_record_to_index'
 """Provide an implemetation of record_to_index function"""
+
+INDEXER_BEFORE_INDEX_HOOKS = []
+"""List of automatically connected hooks (function or importable string)."""

--- a/invenio_indexer/ext.py
+++ b/invenio_indexer/ext.py
@@ -26,11 +26,13 @@
 
 from __future__ import absolute_import, print_function
 
+import six
 from flask import current_app
 from werkzeug.utils import cached_property, import_string
 
 from . import config
 from .cli import run  # noqa
+from .signals import before_record_index
 
 
 class InvenioIndexer(object):
@@ -51,6 +53,12 @@ class InvenioIndexer(object):
         """
         self.init_config(app)
         app.extensions['invenio-indexer'] = self
+
+        hooks = app.config.get('INDEXER_BEFORE_INDEX_HOOKS', [])
+        for hook in hooks:
+            if isinstance(hook, six.string_types):
+                hook = import_string(hook)
+            before_record_index.connect_via(app)(hook)
 
     def init_config(self, app):
         """Initialize configuration.

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ install_requires = [
     'Flask>=0.11.1',
     'celery>=3.1.19',
     'invenio-records>=1.0.0a8',
-    'invenio-search>=1.0.0a4',
+    'invenio-search>=1.0.0a7',
     'pytz>=2016.4',
 ]
 

--- a/tests/test_invenio_bulkindexer.py
+++ b/tests/test_invenio_bulkindexer.py
@@ -26,9 +26,19 @@
 
 from __future__ import absolute_import, print_function
 
+import uuid
+
+import pytz
 from flask import Flask
+from invenio_db import db
+from invenio_records import Record
+from mock import MagicMock
 
 from invenio_indexer import InvenioIndexer
+from invenio_indexer.api import RecordIndexer
+
+_global_magic_hook = MagicMock()
+"""Iternal importable magic hook instance."""
 
 
 def test_version():
@@ -48,3 +58,47 @@ def test_init():
     assert 'invenio-indexer' not in app.extensions
     ext.init_app(app)
     assert 'invenio-indexer' in app.extensions
+
+
+def test_hook_initialization(base_app):
+    """Test hook initialization."""
+    app = base_app
+    magic_hook = MagicMock()
+    app.config['INDEXER_BEFORE_INDEX_HOOKS'] = [
+        magic_hook, 'test_invenio_bulkindexer:_global_magic_hook'
+    ]
+    ext = InvenioIndexer(app)
+
+    with app.app_context():
+        recid = uuid.uuid4()
+        record = Record.create({'title': 'Test'}, id_=recid)
+        db.session.commit()
+
+        client_mock = MagicMock()
+        RecordIndexer(search_client=client_mock, version_type='force').index(
+            record)
+        args = (app, )
+        kwargs = dict(
+            index=app.config['INDEXER_DEFAULT_INDEX'],
+            doc_type=app.config['INDEXER_DEFAULT_DOC_TYPE'],
+            record=record,
+            json={
+                'title': 'Test',
+                '_created': pytz.utc.localize(record.created).isoformat(),
+                '_updated': pytz.utc.localize(record.updated).isoformat(),
+            },
+        )
+        magic_hook.assert_called_with(*args, **kwargs)
+        _global_magic_hook.assert_called_with(*args, **kwargs)
+        client_mock.index.assert_called_with(
+            id=str(recid),
+            version=0,
+            version_type='force',
+            index=app.config['INDEXER_DEFAULT_INDEX'],
+            doc_type=app.config['INDEXER_DEFAULT_DOC_TYPE'],
+            body={
+                'title': 'Test',
+                '_created': pytz.utc.localize(record.created).isoformat(),
+                '_updated': pytz.utc.localize(record.updated).isoformat(),
+            },
+        )


### PR DESCRIPTION
In the init_app, connects functions provided in the INDEXER_BEFORE_INDEX_HOOKS config variable to the before_record_index signal.

--
addresses #46 