### PR TITLE
Allow arguments for bulk indexing API and release v1.0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.0.1 (released 2018-10-11)
+
+- Allow forwarding arguments from ``RecordIndexer.process_bulk_queue`` to
+  ``elasticsearch.helpers.bulk`` calls via the ``es_bulk_kwargs`` parameter.
+
 Version 1.0.0 (released 2018-03-23)
 
 - Initial public release.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,6 +325,8 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'kombu': ('http://docs.celeryproject.org/projects/kombu/en/latest/', None),
+    'elasticsearch': (
+        'https://elasticsearch-py.readthedocs.io/en/master/', None),
 }
 # Autodoc configuraton.
 autoclass_content = 'both'

--- a/invenio_indexer/api.py
+++ b/invenio_indexer/api.py
@@ -61,10 +61,10 @@ class RecordIndexer(object):
             from the record.
         """
         self.client = search_client or current_search_client
-        self._exchange = None
-        self._queue = None
+        self._exchange = exchange
+        self._queue = queue
         self._record_to_index = record_to_index or current_record_to_index
-        self._routing_key = None
+        self._routing_key = routing_key
         self._version_type = version_type or 'external_gte'
 
     def record_to_index(self, record):

--- a/invenio_indexer/tasks.py
+++ b/invenio_indexer/tasks.py
@@ -16,14 +16,17 @@ from .api import RecordIndexer
 
 
 @shared_task(ignore_result=True)
-def process_bulk_queue(version_type=None):
+def process_bulk_queue(version_type=None, es_bulk_kwargs=None):
     """Process bulk indexing queue.
 
-    :param version_type: Elasticsearch version type.
+    :param str version_type: Elasticsearch version type.
+    :param dict es_bulk_kwargs: Passed to
+        :func:`elasticsearch:elasticsearch.helpers.bulk`.
 
     Note: You can start multiple versions of this task.
     """
-    RecordIndexer(version_type=version_type).process_bulk_queue()
+    RecordIndexer(version_type=version_type).process_bulk_queue(
+        es_bulk_kwargs=es_bulk_kwargs)
 
 
 @shared_task(ignore_result=True)

--- a/invenio_indexer/version.py
+++ b/invenio_indexer/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
This allows solving the issue where a version conflict during a run of the celery bulk indexing task (which might be actually fine, e.g. in case a record was synchronously indexed after also have being sent for bulk indexing), makes the entire task fail.