### PR TITLE
Bug Fix: Pin Redis version in order to avoid Redis v3 incompatibilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ install_requires = [
     'invenio-pidstore>=1.0.0',
     'invenio-records>=1.0.0',
     'pytz>=2016.4',
+    'redis>=2.10.0,<3.0.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-indexer/issues/93

Pin Redis library to <3.0.0 Due to some incompatibilities. They have been addressed in Kombu, therefore awaiting for a release ( https://github.com/celery/kombu/pull/953 ).