### PR TITLE
Revert "installation: pin Redis due to v3 incompatibility"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ install_requires = [
     'invenio-pidstore>=1.0.0',
     'invenio-records>=1.0.0',
     'pytz>=2016.4',
-    'redis>=2.10.0,<3.0.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
This reverts commit 9749c2fe4e2cbaabc167ad7fb12ade945a2d580c.