### PR TITLE
api: allow customization of ES indexing arguments.

### DIFF
--- a/invenio_indexer/signals.py
+++ b/invenio_indexer/signals.py
@@ -25,3 +25,16 @@ provided:
 - ``index``: The index in which the record will be indexed.
 - ``doc_type``: The doc_type for the record.
 """
+
+before_record_index_arguments = _signals.signal('before-record-index-args')
+"""Signal sent before a record is indexed.
+
+The sender is the current Flask application, and two keyword arguments are
+provided:
+
+- ``json``: The dumped record dictionary which can be modified.
+- ``record``: The record being indexed.
+- ``index``: The index in which the record will be indexed.
+- ``doc_type``: The doc_type for the record.
+- ``**kwargs``: Extra arguments.
+"""


### PR DESCRIPTION
Allow indexing arguments to reach the low level client. Partially fixes https://github.com/inveniosoftware/invenio-records-files/issues/53 by allowing to attach to a signal where to modify the parameter according to the necessity (e.g. adding a 'pipeline=attachment' argument).

Doubts:

- Should ``**kwargs`` be passed to when ``client.index(...)`` (#L19) . Or we assume that ``arguments`` would suffice, since there everything can be added and ``**kwargs`` reaches this function empty (it is not passed from ``invenio-records-rest``, but should be there for consistency). 

Tested in CERN Search (ES6 - Python 3.4) and working as expected.