### PR TITLE
api: allow customization of ES indexing arguments.

### DIFF
--- a/invenio_indexer/signals.py
+++ b/invenio_indexer/signals.py
@@ -24,4 +24,6 @@ provided:
 - ``record``: The record being indexed.
 - ``index``: The index in which the record will be indexed.
 - ``doc_type``: The doc_type for the record.
+- ``arguments``: The arguments to pass to Elasticsearch for indexing.
+- ``**kwargs``: Extra arguments.
 """

--- a/tests/test_invenio_bulkindexer.py
+++ b/tests/test_invenio_bulkindexer.py
@@ -65,6 +65,7 @@ def test_hook_initialization(base_app):
         kwargs = dict(
             index=app.config['INDEXER_DEFAULT_INDEX'],
             doc_type=app.config['INDEXER_DEFAULT_DOC_TYPE'],
+            arguments={},
             record=record,
             json={
                 'title': 'Test',


### PR DESCRIPTION
Replaces https://github.com/inveniosoftware/invenio-indexer/pull/99 due to unconsistent branch naming.

Allow indexing arguments to reach the low level client. Partially fixes https://github.com/inveniosoftware/invenio-records-files/issues/53 by allowing to attach to a signal where to modify the parameter according to the necessity (e.g. adding a 'pipeline=attachment' argument).

Doubts:

- [**SOLVED**] Should ``**kwargs`` be passed to when ``client.index(...)`` (#L19) . Or we assume that ``arguments`` would suffice, since there everything can be added and ``**kwargs`` reaches this function empty (it is not passed from ``invenio-records-rest``, but should be there for consistency). 

Tested in CERN Search (ES6 - Python 3.6) and working as expected.