### PR TITLE
support custom record classes on the indexer

### DIFF
--- a/invenio_indexer/api.py
+++ b/invenio_indexer/api.py
@@ -53,7 +53,8 @@ class RecordIndexer(object):
     record_cls = Record
 
     def __init__(self, search_client=None, exchange=None, queue=None,
-                 routing_key=None, version_type=None, record_to_index=None):
+                 routing_key=None, version_type=None, record_to_index=None,
+                 record_cls=None):
         """Initialize indexer.
 
         :param search_client: Elasticsearch client.
@@ -72,6 +73,9 @@ class RecordIndexer(object):
         self._record_to_index = record_to_index or current_record_to_index
         self._routing_key = routing_key
         self._version_type = version_type or 'external_gte'
+
+        if record_cls:
+            self.record_cls = record_cls
 
     def record_to_index(self, record):
         """Get index/doc_type given a record.

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,9 @@ history = open('CHANGES.rst').read()
 
 tests_require = [
     'attrs>=17.4.0',
-    'check-manifest>=0.25',
-    'coverage>=4.0',
     'invenio-db[versioning]>=1.0.0',
-    'isort>=4.3.21',
     'mock>=1.3.0',
-    'pydocstyle>=1.0.0',
-    'pytest-cov>=1.8.0',
-    'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest-invenio>=1.3.2',
     'redis>=2.10.0',
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -341,3 +341,16 @@ def test_before_record_index_dynamic_connect(app):
 
         before_record_index.disconnect(_receiver1)
         before_record_index.disconnect(_receiver2)
+
+
+def test_indexer_record_class():
+    """Tests the usage of a custom record class."""
+    class DummyRecord:
+        """Dummy record class."""
+        pass
+
+    indexer = RecordIndexer()
+    assert indexer.record_cls == Record
+
+    indexer = RecordIndexer(record_cls=DummyRecord)
+    assert indexer.record_cls == DummyRecord


### PR DESCRIPTION
- Fixes pytest deprecation warnings
- Migrates to centrally managed test depenencies
- Fixes new isort syntax
- Adds support for custom record classes

... For some reason travis fails on docs building...

Closes https://github.com/inveniosoftware/invenio-indexer/issues/119