### PR TITLE
api: new-style record dumping and optimistic concurrency control for delete

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
 Changes
 =======
 
-Version 1.2.0 (released TBD)
+Version 1.2.0 (released 2020-09-16)
 
 - Changes delete requests to optimistic concurrency control by providing the
   the version and version_type in delete requests. The previous behavior can

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,16 @@
 Changes
 =======
 
+Version 1.2.0 (released TBD)
+
+- Changes delete requests to optimistic concurrency control by providing the
+  the version and version_type in delete requests. The previous behavior can
+  restored by calling
+  ``RecordIndexer().delete(record, version=None, version_type=None)`` instead.
+
+- Adds support for using new-style record dumping controlled via the
+  ``Record.enable_jsonref`` flag.
+
 Version 1.1.2 (released 2020-04-28)
 
 - Introduces ``RecordIndexer.record_cls`` for customizing the record class.

--- a/invenio_indexer/version.py
+++ b/invenio_indexer/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.0a1.dev0'
+__version__ = '1.2.0'

--- a/invenio_indexer/version.py
+++ b/invenio_indexer/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.2'
+__version__ = '1.2.0a1.dev0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,11 +34,11 @@ def base_app(request):
     instance_path = tempfile.mkdtemp()
     app = Flask('testapp', instance_path=instance_path)
     app.config.update(
-        BROKER_URL=os.environ.get('BROKER_URL',
-                                  'amqp://guest:guest@localhost:5672//'),
-        CELERY_ALWAYS_EAGER=True,
+        CELERY_BROKER_URL=os.environ.get(
+            'BROKER_URL', 'amqp://guest:guest@localhost:5672//'),
+        CELERY_TASK_ALWAYS_EAGER=True,
         CELERY_CACHE_BACKEND='memory',
-        CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+        CELERY_TASK_EAGER_PROPAGATES=True,
         CELERY_RESULT_BACKEND='cache',
         INDEXER_DEFAULT_INDEX='records-default-v1.0.0',
         INDEXER_DEFAULT_DOC_TYPE='default-v1.0.0',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,7 +69,7 @@ def test_delete_action(app):
         assert action['_id'] == testid
 
         # Skip JSONSchema validation
-        with patch('invenio_records.api.Record.validate'):
+        with patch('invenio_records.api._records_state.validate'):
             record = Record.create({
                 '$schema': {
                     '$ref': '/records/authorities/authority-v1.0.0.json'},
@@ -236,13 +236,13 @@ def test_replace_refs(app):
 
     with app.app_context():
         record = Record({'$ref': 'http://dx.doi.org/10.1234/foo'})
-        data = RecordIndexer._prepare_record(record, 'records', 'record')
+        data = RecordIndexer()._prepare_record(record, 'records', 'record')
         assert '$ref' in data
 
     app.config['INDEXER_REPLACE_REFS'] = True
     with app.app_context():
         record = Record({'$ref': 'http://dx.doi.org/10.1234/foo'})
-        data = RecordIndexer._prepare_record(record, 'records', 'record')
+        data = RecordIndexer()._prepare_record(record, 'records', 'record')
         assert '$ref' not in data
         assert json.dumps(data)
 
@@ -306,7 +306,7 @@ def test_bulkrecordindexer_index_delete_by_record(app, queue):
 def test_before_record_index_dynamic_connect(app):
     """Test before_record_index.dynamic_connect."""
     with app.app_context():
-        with patch('invenio_records.api.Record.validate'):
+        with patch('invenio_records.api._records_state.validate'):
             auth_record = Record.create({
                 '$schema': '/records/authorities/authority-v1.0.0.json',
                 'title': 'Test'})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -221,6 +221,8 @@ def test_delete(app):
             id=str(recid),
             index=app.config['INDEXER_DEFAULT_INDEX'],
             doc_type=doc_type,
+            version=record.revision_id,
+            version_type='external_gte',
         )
 
         with patch('invenio_indexer.api.RecordIndexer.delete') as fun:

--- a/tests/test_invenio_indexer.py
+++ b/tests/test_invenio_indexer.py
@@ -105,7 +105,7 @@ def test_index_prefixing(base_app):
     default_doc_type = app.config['INDEXER_DEFAULT_DOC_TYPE']
 
     with app.app_context():
-        with patch('invenio_records.api.Record.validate'):
+        with patch('invenio_records.api._records_state.validate'):
             record = Record.create({'title': 'Test'})
             record2 = Record.create({
                 '$schema': '/records/authorities/authority-v1.0.0.json',

--- a/tests/test_invenio_indexer.py
+++ b/tests/test_invenio_indexer.py
@@ -176,4 +176,6 @@ def test_index_prefixing(base_app):
                 id=str(record3.id),
                 index='test-' + default_index,
                 doc_type=default_doc_type if lt_es7 else '_doc',
+                version=record3.revision_id,
+                version_type='external_gte',
             )


### PR DESCRIPTION
* Adds support for new-style record dumping that relies solely on
  Record.dumps() to produce the Elasticsearch source document. This is
  in order to allow the Record class to harmonize record dumping/loading
  from multiple different sources.

* Adds usage of optimistic concurrency control for delete requests
      to ensure proper operation of delete requests as well as ensuring
      that documents can be recreated and reindexed immediately after a
      delete request.

* Fixes tests to work with latest Invenio-Records.