### PR TITLE
remove py 2.7 and update tests versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,50 +15,44 @@ on:
     branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
 
 jobs:
   Tests:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9]
-          requirements-level: [min, pypi]
-          cache-service: [redis]
-          mq-service: [rabbitmq, redis]
-          search-service: [elasticsearch6, elasticsearch7]
-          exclude:
-          - python-version: 3.6
+        python-version: [3.7, 3.8, 3.9]
+        requirements-level: [min, pypi]
+        cache-service: [redis]
+        mq-service: [rabbitmq, redis]
+        search-service: [elasticsearch6, elasticsearch7]
+        exclude:
+          - python-version: 3.7
             requirements-level: pypi
 
-          - python-version: 3.7
-            requirements-level: min
-
           - python-version: 3.8
             requirements-level: min
 
           - python-version: 3.9
             requirements-level: min
 
-          - python-version: 3.6
+          - python-version: 3.7
             search-service: elasticsearch7
 
-          - python-version: 3.7
-            search-service: elasticsearch6
-
           - python-version: 3.8
             search-service: elasticsearch6
 
           - python-version: 3.9
             search-service: elasticsearch6
 
-          include:
+        include:
           - search-service: elasticsearch6
             SEARCH_EXTRAS: "elasticsearch6"
 

--- a/invenio_indexer/__init__.py
+++ b/invenio_indexer/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -177,8 +177,6 @@ If specific types of records have different rules (e.g. in case you had
 >>> res = before_record_index.dynamic_connect(
 ...     indexer_receiver, sender=app, index='authors-v1.0.0')
 """
-
-from __future__ import absolute_import, print_function
 
 from .ext import InvenioIndexer
 from .proxies import current_record_to_index

--- a/invenio_indexer/api.py
+++ b/invenio_indexer/api.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """API for indexing of records."""
-
-from __future__ import absolute_import, print_function
 
 import copy
 from contextlib import contextmanager

--- a/invenio_indexer/cli.py
+++ b/invenio_indexer/cli.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """CLI for indexer."""
-
-from __future__ import absolute_import, print_function
 
 import click
 from celery.messaging import establish_connection

--- a/invenio_indexer/config.py
+++ b/invenio_indexer/config.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Record indexer for Invenio."""
-
-from __future__ import absolute_import, print_function
 
 from kombu import Exchange, Queue
 

--- a/invenio_indexer/ext.py
+++ b/invenio_indexer/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 # Copyright (C) 2016 TIND.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -9,9 +9,6 @@
 
 """Flask exension for Invenio-Indexer."""
 
-from __future__ import absolute_import, print_function
-
-import six
 from flask import current_app
 from werkzeug.utils import cached_property, import_string
 
@@ -41,7 +38,7 @@ class InvenioIndexer(object):
 
         hooks = app.config.get('INDEXER_BEFORE_INDEX_HOOKS', [])
         for hook in hooks:
-            if isinstance(hook, six.string_types):
+            if isinstance(hook, str):
                 hook = import_string(hook)
             before_record_index.connect_via(app)(hook)
 

--- a/invenio_indexer/signals.py
+++ b/invenio_indexer/signals.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Signals for indexer."""
-
-from __future__ import absolute_import, print_function
 
 from types import MethodType
 

--- a/invenio_indexer/tasks.py
+++ b/invenio_indexer/tasks.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Celery tasks to index records."""
-
-from __future__ import absolute_import, print_function
 
 from celery import shared_task
 

--- a/invenio_indexer/utils.py
+++ b/invenio_indexer/utils.py
@@ -11,7 +11,6 @@
 import os
 from functools import wraps
 
-import six
 from elasticsearch import VERSION as ES_VERSION
 from flask import current_app
 from invenio_search import current_search
@@ -79,7 +78,7 @@ def default_record_to_index(record):
 def _es7_expand_action(data):
     """ES7-compatible bulk action expand."""
     # when given a string, assume user wants to index raw json
-    if isinstance(data, six.string_types):
+    if isinstance(data, str):
         return '{"index":{}}', data
 
     # make sure we don't alter the action

--- a/invenio_indexer/version.py
+++ b/invenio_indexer/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2019 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,7 +11,5 @@
 This file is imported by ``invenio_indexer.__init__``,
 and parsed by ``setup.py``.
 """
-
-from __future__ import absolute_import, print_function
 
 __version__ = '1.2.2'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'attrs>=17.4.0',
     'pytest-invenio>=1.4.6',
-    'redis>=3.2.0',
+    'redis>=3.4.0',
 ]
 
 invenio_search_version = '1.4.0'
@@ -98,9 +98,9 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Development Status :: 5 - Production/Stable',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration."""
-
-from __future__ import absolute_import, print_function
 
 import os
 import shutil

--- a/tests/demo/json_resolver.py
+++ b/tests/demo/json_resolver.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test JSON resolver."""
-
-from __future__ import absolute_import, print_function
 
 import jsonresolver
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test API."""
-
-from __future__ import absolute_import, print_function
 
 import json
 import uuid

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test CLI."""
-
-from __future__ import absolute_import, print_function
 
 import uuid
 

--- a/tests/test_invenio_indexer.py
+++ b/tests/test_invenio_indexer.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Module tests."""
-
-from __future__ import absolute_import, print_function
 
 import uuid
 from unittest.mock import MagicMock, patch

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test celery task."""
-
-from __future__ import absolute_import, print_function
 
 import uuid
 from unittest.mock import patch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2019 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test API."""
-
-from __future__ import absolute_import, print_function
 
 from unittest.mock import patch
 


### PR DESCRIPTION
On a potential release, this is a major? I guess not since python 2.7 was removed long ago is just that imports were still laying around.