### PR TITLE
global: add indexer registry

### DIFF
--- a/invenio_indexer/ext.py
+++ b/invenio_indexer/ext.py
@@ -14,6 +14,7 @@ from werkzeug.utils import cached_property, import_string
 
 from . import config
 from .cli import run  # noqa
+from .registry import IndexerRegistry
 from .signals import before_record_index
 
 
@@ -34,6 +35,7 @@ class InvenioIndexer(object):
         :param app: The Flask application.
         """
         self.init_config(app)
+        self.registry = IndexerRegistry()
         app.extensions['invenio-indexer'] = self
 
         hooks = app.config.get('INDEXER_BEFORE_INDEX_HOOKS', [])

--- a/invenio_indexer/proxies.py
+++ b/invenio_indexer/proxies.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2022 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -17,3 +17,8 @@ def _get_current_record_to_index():
 
 
 current_record_to_index = LocalProxy(_get_current_record_to_index)
+
+current_indexer_registry = LocalProxy(
+    lambda: current_app.extensions['invenio-indexer'].registry
+)
+"""Helper proxy to get the current indexer registry."""

--- a/invenio_indexer/registry.py
+++ b/invenio_indexer/registry.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Indexer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Indexer registry."""
+
+
+class IndexerRegistry:
+    """A simple class to register indexers."""
+
+    def __init__(self):
+        """Initialize the registry."""
+        self._indexers = {}
+
+    def register(self, indexer_instance, indexer_id):
+        """Register a new indexer instance."""
+        if indexer_id in self._indexers:
+            raise RuntimeError(
+                f"Indexer with indexer id '{indexer_id}' "
+                "is already registered."
+            )
+        self._indexers[indexer_id] = indexer_instance
+
+    def get(self, indexer_id):
+        """Get an indexer for a given indexer_id."""
+        return self._indexers[indexer_id]
+
+    def get_indexer_id(self, instance):
+        """Get the indexer id for a specific instance."""
+        for indexer_id, indexer_instance in self._indexers.items():
+            if instance == indexer_instance:
+                return indexer_id
+        raise KeyError("Indexer not found in registry.")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Indexer registry module tests."""
+
+import pytest
+
+from invenio_indexer.api import RecordIndexer
+from invenio_indexer.proxies import current_indexer_registry
+
+
+def test_indexer_registry(app):
+    indexer_instance = RecordIndexer()
+    current_indexer_registry.register(indexer_instance, "test")
+
+    # fail on duplicate id
+    pytest.raises(
+        RuntimeError,
+        current_indexer_registry.register,
+        indexer_instance,
+        "test"
+    )
+    # get indexer
+    assert indexer_instance == current_indexer_registry.get("test")
+    # get id
+    assert "test" == current_indexer_registry.get_indexer_id(indexer_instance)
+    # get id of non-registered indexer
+    pytest.raises(
+        KeyError, current_indexer_registry.get_indexer_id, RecordIndexer()
+    )


### PR DESCRIPTION
- closes #132 
- closes #117 

**Description**
The idea behind this is to allow customization of the full indexer (record class, dumper, record to index function, etc.), see more information in the closing issues.

**Alternatives**
- Create a factory-like function (e.g. `create_indexer`) and pass the parameters to the tasks (e.g. `record_cls_str`) and then use `load_or_import_from_config` to instantiate the indexer. This would end up in a rather complex amount of cases and parameter passing.
- Keep the module as is, and create a more flexible task in `records-resources` or somewhere up the hierarchy. This would not benefit people using the framework.

**Questions**
- Where would the indexers be registered?
    a) For RDM, in the service registry. Add a flag (e.g. indexer=True) and then upon `current_service_registry.register(...)` register the indexer. This way it would be transparent, it would use the same name. **It requires standarizing names of services, to not have the word "service" in them.**
    b) Separately, in the views.py, as done with services.

I'm leaning towards a), then for non RDM instances it can be done in the ext/views of whatever "top level" module they are implementing (e.g. invenio-app-ils).

**Important notes**
Indexers are record class specific, therefore each call to the tasks should be done to a separate queue.

## Decissions

After IRL discussions:
- Registry ✅ (no other of the alternatives)
- Registration from the service registry (apply naming convention).