### PR TITLE
release: v1.2.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.2.3 (released 2022-04-06)
+
+- Add indexer registry and use it in celery tasks.
+
 Version 1.2.2 (released 2022-03-30)
 
 - Add support for Click v8.1+ and Flask v2.1+.

--- a/invenio_indexer/version.py
+++ b/invenio_indexer/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_indexer.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'


### PR DESCRIPTION
There is no change that is back incompatible, python 2 support was dropped in the change from 1.1 to 1.2. Therefore, a patch release is ok.