### PR TITLE
indexer: declare queues on publish

### DIFF
--- a/invenio_indexer/api.py
+++ b/invenio_indexer/api.py
@@ -268,12 +268,13 @@ class RecordIndexer(object):
         """
         with self.create_producer() as producer:
             for rec in record_id_iterator:
-                producer.publish(dict(
+                data = dict(
                     id=str(rec),
                     op=op_type,
                     index=index,
-                    doc_type=doc_type
-                ))
+                    doc_type=doc_type,
+                )
+                producer.publish(data, declare=[self.mq_queue])
 
     def _actionsiter(self, message_iterator):
         """Iterate bulk actions.


### PR DESCRIPTION
(On redis) When producing messages for the first time the queue has not been declare and therefore they are lost (no exception is raised). Adding the `declare` parameter to the `publish()` call will ensure the queue exists before pushing messages to it. Note that the `auto_declare` flag enabled in the producer only applies to the _exchange_ not to _queues_.