### PR TITLE
indexer: Allow the definition of indices in index_templates, instead …

### DIFF
--- a/invenio_indexer/utils.py
+++ b/invenio_indexer/utils.py
@@ -53,7 +53,10 @@ def default_record_to_index(record):
     :param record: The record object.
     :returns: index.
     """
-    index_names = current_search.mappings.keys()
+    # The indices could be defined either in the mappings or in the index_templates
+    index_names = list(current_search.mappings.keys()) + list(
+        current_search.index_templates.keys()
+    )
     schema = record.get("$schema", "")
     if isinstance(schema, dict):
         schema = schema.get("$ref", "")

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,11 +42,11 @@ tests =
 elasticsearch7 =
     # needed: 7.5.0 integrates https://github.com/elastic/elasticsearch-py/pull/1062
     elasticsearch>=7.5.0,<7.14.0
-    invenio-search[elasticsearch7]>=2.1.0,<3.0.0
+    invenio-search[elasticsearch7]>=2.3.0,<3.0.0
 opensearch1 =
-    invenio-search[opensearch1]>=2.1.0,<3.0.0
+    invenio-search[opensearch1]>=2.3.0,<3.0.0
 opensearch2 =
-    invenio-search[opensearch2]>=2.1.0,<3.0.0
+    invenio-search[opensearch2]>=2.3.0,<3.0.0
 # Kept for backwards compatibility
 docs =
 


### PR DESCRIPTION
Indices could be defined either with `mappings` or with `index_templates`